### PR TITLE
fix: route apple silicon macs to x86_64

### DIFF
--- a/repackimg.sh
+++ b/repackimg.sh
@@ -16,6 +16,9 @@ case $(uname -s) in
   *) plat="linux";;
 esac;
 arch=$plat/`uname -m`;
+case $arch in
+macos/arm64) arch=macos/x86_64 ;; # fix for Apple Silicon
+esac
 
 aik="${BASH_SOURCE:-$0}";
 aik="$(dirname "$(readlink -f "$aik")")";

--- a/unpackimg.sh
+++ b/unpackimg.sh
@@ -25,6 +25,9 @@ case $(uname -s) in
   *) plat="linux";;
 esac;
 arch=$plat/`uname -m`;
+case $arch in
+macos/arm64) arch=macos/x86_64 ;; # fix for Apple Silicon
+esac
 
 aik="${BASH_SOURCE:-$0}";
 aik="$(dirname "$(readlink -f "$aik")")";


### PR DESCRIPTION
This PR fixes(or, let's be honest, temporary fixes) the executables not set properly on Apple Silicon Macs.

The best fix would be to make binaries for macos/arm64, but I have no time for that lol.